### PR TITLE
Support Rails 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ rvm:
   - 1.9.3
 
 notifications:
-  irc: "irc.freenode.org#axlsx
+  irc: "irc.freenode.org#axlsx"
 

--- a/acts_as_xlsx.gemspec
+++ b/acts_as_xlsx.gemspec
@@ -21,6 +21,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'activerecord', '>= 2.3.9'
   s.add_runtime_dependency 'i18n', '>= 0.4.1'
   
+  if RUBY_VERSION == "2.0.0"
+    s.add_development_dependency 'rake'
+    s.add_development_dependency 'minitest'
+  end
   s.add_development_dependency 'rake', "0.8.7" if RUBY_VERSION == "1.9.2"
   s.add_development_dependency 'rake', "~> 0.9" if ["1.9.3", "1.8.7"].include?(RUBY_VERSION)
   s.add_development_dependency 'bundler'

--- a/lib/acts_as_xlsx/ar.rb
+++ b/lib/acts_as_xlsx/ar.rb
@@ -84,7 +84,7 @@ module Axlsx
           data.each do |r|
             row_data = columns.map do |c|
               if c.to_s =~ /\./
-                v = r; c.to_s.split('.').each { |method| v = v.send(method) }; v
+                v = r; c.to_s.split('.').each { |method| !v.nil? ? v = v.send(method) : v = ""; }; v
               else
                 r.send(c)                
               end

--- a/lib/acts_as_xlsx/ar.rb
+++ b/lib/acts_as_xlsx/ar.rb
@@ -62,7 +62,11 @@ module Axlsx
         header_style = p.workbook.styles.add_style(header_style) unless header_style.nil?
         i18n = self.xlsx_i18n == true ? 'activerecord.attributes' : i18n
         sheet_name = options.delete(:name) || (i18n ? I18n.t("#{i18n}.#{table_name.underscore}") : table_name.humanize) 
-        data = options.delete(:data) || [*find(:all, options)]
+        if Rails.version[0] >= '4'
+          data = options.delete(:data) || where(options[:where]).order(options[:order]).to_a
+        else
+          data = options.delete(:data) || [*find(:all, options)]
+        end
         data.compact!
         data.flatten!
 


### PR DESCRIPTION
Hey there. I've been updating axlsx_rails to support Rails 4.1, and found you need this change for acts_as_axlsx. The find(:all) method is no longer available.

I don't see any explicit documentation for passing options to the find(:all) method. I've guessed for Rails 4.1 that where(conditions) and order(order) would be useful. Perhaps the data option should be documented. Thoughts?
